### PR TITLE
add envvar.enum

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014 Plaid Technologies, Inc.
+Copyright (c) 2014..2016 Plaid Technologies, Inc.
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ envvar is a tiny JavaScript package for deriving JavaScript values from
 environment variables.
 
 ```javascript
-var envvar = require('envvar');
+const envvar = require('envvar');
 
-var GITHUB_API_TOKEN = envvar.string('GITHUB_API_TOKEN');
-var HTTP_MAX_SOCKETS = envvar.number('HTTP_MAX_SOCKETS');
-var ENABLE_FEATURE_X = envvar.boolean('ENABLE_FEATURE_X', false);
+const GITHUB_API_TOKEN = envvar.string('GITHUB_API_TOKEN');
+const HTTP_MAX_SOCKETS = envvar.number('HTTP_MAX_SOCKETS');
+const ENABLE_FEATURE_X = envvar.boolean('ENABLE_FEATURE_X', false);
 ```
 
 If one argument is provided the environment variable is __required__. If the
@@ -30,4 +30,23 @@ a suitable value, an `envvar.ValueError` is thrown:
 
     ValueError: Value of process.env["HTTP_MAX_SOCKETS"] does not represent a number
 
-That's all there is to it.
+### `envvar.enum`
+
+This is similar to `envvar.string`, but with constraints. There may be a small
+number of valid values for a given environment variable. For example:
+
+```javascript
+const NODE_ENV = envvar.enum('NODE_ENV', ['development', 'staging', 'production']);
+```
+
+This states that `process.env.NODE_ENV` must be set to `development`,
+`staging`, or `production`.
+
+A default value may be provided:
+
+```javascript
+const NODE_ENV = envvar.enum('NODE_ENV', ['development', 'staging', 'production'], 'production');
+```
+
+This states that `process.env.NODE_ENV` must either be unset (in which case the
+default value is assumed), or set to `development`, `staging`, or `production`.

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,16 @@
+dependencies:
+  override:
+    - make setup
+
 machine:
   node:
-    version: 0.10.28
+    version: 0.10.34
 
 test:
   override:
-    - make test lint
+    - make lint
+    - make test
+    - nvm install 0.12.7
+    - nvm use 0.12.7 && rm -r node_modules && make setup test
+    - nvm use 4 && rm -r node_modules && make setup test
+    - nvm use 5 && rm -r node_modules && make setup test

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "istanbul": "0.3.x",
-    "jshint": "2.5.x",
+    "istanbul": "0.4.x",
+    "jshint": "2.9.x",
     "mocha": "2.x.x",
     "xyz": "0.5.x"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -9,11 +9,13 @@ var envvar = require('..');
 
 var eq = assert.strictEqual;
 
-function createMatcher(type, message) {
+var errorEq = function(type, message) {
   return function(err) {
-    return err instanceof type && err.message === message;
+    return err.name === type.name && err.message === message;
   };
-}
+};
+
+var throws = assert.throws;
 
 
 beforeEach(function() { delete process.env.FOO; });
@@ -55,27 +57,35 @@ describe('envvar.ValueError', function() {
 
 describe('envvar.boolean', function() {
 
-  it('coerces value to Boolean', function() {
-    process.env.FOO = 'true';
-    eq(envvar.boolean('FOO'), true);
+  it('throws if applied to too few arguments', function() {
+    throws(function() { envvar.boolean(); },
+           errorEq(Error, 'Too few arguments'));
+  });
 
-    process.env.FOO = 'false';
-    eq(envvar.boolean('FOO'), false);
+  it('throws if applied to too many arguments', function() {
+    throws(function() { envvar.boolean(1, 2, 3); },
+           errorEq(Error, 'Too many arguments'));
+  });
+
+  it('throws a TypeError if default value is not Boolean', function() {
+    throws(function() { envvar.boolean('FOO', 'true'); },
+           errorEq(TypeError,
+                   'Default value of process.env["FOO"] ' +
+                   'is not of type Boolean'));
   });
 
   it('throws a ValueError if value is neither "true" nor "false"', function() {
     process.env.FOO = '1';
-    assert.throws(function() { envvar.boolean('FOO'); }, createMatcher(
-      envvar.ValueError,
-      'Value of process.env["FOO"] is neither "true" nor "false"'
-    ));
+    throws(function() { envvar.boolean('FOO'); },
+           errorEq(envvar.ValueError,
+                   'Value of process.env["FOO"] ' +
+                   'is neither "true" nor "false"'));
   });
 
   it('throws an UnsetVariableError if variable is not set', function() {
-    assert.throws(function() { envvar.boolean('FOO'); }, createMatcher(
-      envvar.UnsetVariableError,
-      'No environment variable named "FOO"'
-    ));
+    throws(function() { envvar.boolean('FOO'); },
+           errorEq(envvar.UnsetVariableError,
+                   'No environment variable named "FOO"'));
   });
 
   it('returns default value if variable is not set', function() {
@@ -93,11 +103,12 @@ describe('envvar.boolean', function() {
     eq(envvar.boolean('FOO', false), false);
   });
 
-  it('throws a TypeError if default value is not Boolean', function() {
-    assert.throws(function() { envvar.boolean('FOO', 'true'); }, createMatcher(
-      TypeError,
-      'Default value of process.env["FOO"] is not of type Boolean'
-    ));
+  it('coerces value to Boolean', function() {
+    process.env.FOO = 'true';
+    eq(envvar.boolean('FOO'), true);
+
+    process.env.FOO = 'false';
+    eq(envvar.boolean('FOO'), false);
   });
 
 });
@@ -105,24 +116,34 @@ describe('envvar.boolean', function() {
 
 describe('envvar.number', function() {
 
-  it('coerces value to number', function() {
-    process.env.FOO = '42';
-    eq(envvar.number('FOO'), 42);
+  it('throws if applied to too few arguments', function() {
+    throws(function() { envvar.number(); },
+           errorEq(Error, 'Too few arguments'));
+  });
+
+  it('throws if applied to too many arguments', function() {
+    throws(function() { envvar.number(1, 2, 3); },
+           errorEq(Error, 'Too many arguments'));
+  });
+
+  it('throws a TypeError if default value is not a number', function() {
+    throws(function() { envvar.number('FOO', '42'); },
+           errorEq(TypeError,
+                   'Default value of process.env["FOO"] ' +
+                   'is not of type Number'));
   });
 
   it('throws a ValueError if value does not represent a number', function() {
     process.env.FOO = '1.2.3';
-    assert.throws(function() { envvar.number('FOO'); }, createMatcher(
-      envvar.ValueError,
-      'Value of process.env["FOO"] does not represent a number'
-    ));
+    throws(function() { envvar.number('FOO'); },
+           errorEq(envvar.ValueError,
+                   'Value of process.env["FOO"] does not represent a number'));
   });
 
   it('throws an UnsetVariableError if variable is not set', function() {
-    assert.throws(function() { envvar.number('FOO'); }, createMatcher(
-      envvar.UnsetVariableError,
-      'No environment variable named "FOO"'
-    ));
+    throws(function() { envvar.number('FOO'); },
+           errorEq(envvar.UnsetVariableError,
+                   'No environment variable named "FOO"'));
   });
 
   it('returns default value if variable is not set', function() {
@@ -134,11 +155,9 @@ describe('envvar.number', function() {
     eq(envvar.number('FOO', 42), 123.45);
   });
 
-  it('throws a TypeError if default value is not a number', function() {
-    assert.throws(function() { envvar.number('FOO', '42'); }, createMatcher(
-      TypeError,
-      'Default value of process.env["FOO"] is not of type Number'
-    ));
+  it('coerces value to number', function() {
+    process.env.FOO = '42';
+    eq(envvar.number('FOO'), 42);
   });
 
 });
@@ -146,16 +165,27 @@ describe('envvar.number', function() {
 
 describe('envvar.string', function() {
 
-  it('returns value', function() {
-    process.env.FOO = 'quux';
-    eq(envvar.string('FOO'), 'quux');
+  it('throws if applied to too few arguments', function() {
+    throws(function() { envvar.string(); },
+           errorEq(Error, 'Too few arguments'));
+  });
+
+  it('throws if applied to too many arguments', function() {
+    throws(function() { envvar.string(1, 2, 3); },
+           errorEq(Error, 'Too many arguments'));
+  });
+
+  it('throws a TypeError if default value is not a string', function() {
+    throws(function() { envvar.string('FOO', 42); },
+           errorEq(TypeError,
+                   'Default value of process.env["FOO"] ' +
+                   'is not of type String'));
   });
 
   it('throws an UnsetVariableError if variable is not set', function() {
-    assert.throws(function() { envvar.string('FOO'); }, createMatcher(
-      envvar.UnsetVariableError,
-      'No environment variable named "FOO"'
-    ));
+    throws(function() { envvar.string('FOO'); },
+           errorEq(envvar.UnsetVariableError,
+                   'No environment variable named "FOO"'));
   });
 
   it('returns default value if variable is not set', function() {
@@ -167,11 +197,69 @@ describe('envvar.string', function() {
     eq(envvar.string('FOO', 'quux'), 'baz');
   });
 
+  it('returns value', function() {
+    process.env.FOO = 'quux';
+    eq(envvar.string('FOO'), 'quux');
+  });
+
+});
+
+
+describe('envvar.enum', function() {
+
+  it('throws if applied to too few arguments', function() {
+    throws(function() { envvar.enum(); },
+           errorEq(Error, 'Too few arguments'));
+    throws(function() { envvar.enum(1); },
+           errorEq(Error, 'Too few arguments'));
+  });
+
+  it('throws if applied to too many arguments', function() {
+    throws(function() { envvar.enum(1, 2, 3, 4); },
+           errorEq(Error, 'Too many arguments'));
+  });
+
+  it('throws a TypeError if the type contains non-string members', function() {
+    throws(function() { envvar.enum('FOO', ['0', '1', 2]); },
+           errorEq(TypeError,
+                   'Enumerated types must consist solely of string values'));
+    throws(function() { envvar.enum('FOO', ['0', '1', 2], '0'); },
+           errorEq(TypeError,
+                   'Enumerated types must consist solely of string values'));
+  });
+
   it('throws a TypeError if default value is not a string', function() {
-    assert.throws(function() { envvar.string('FOO', 42); }, createMatcher(
-      TypeError,
-      'Default value of process.env["FOO"] is not of type String'
-    ));
+    throws(function() { envvar.enum('FOO', ['0', '1', '2'], 0); },
+           errorEq(TypeError,
+                   'Default value of process.env["FOO"] ' +
+                   'is not of type String'));
+  });
+
+  it('returns default value if variable is not set', function() {
+    eq(envvar.enum('FOO', ['0', '1', '2'], '0'), '0');
+  });
+
+  it('throws an UnsetVariableError if variable is not set', function() {
+    throws(function() { envvar.enum('FOO', ['0', '1', '2']); },
+           errorEq(envvar.UnsetVariableError,
+                   'No environment variable named "FOO"'));
+  });
+
+  it('throws a ValueError if value is not a member of the type', function() {
+    process.env.FOO = 'X';
+    throws(function() { envvar.enum('FOO', ['0', '1', '2']); },
+           errorEq(envvar.ValueError,
+                   'Value of process.env["FOO"] ' +
+                   'is not a member of (0 | 1 | 2)'));
+    throws(function() { envvar.enum('FOO', ['0', '1', '2'], '0'); },
+           errorEq(envvar.ValueError,
+                   'Value of process.env["FOO"] ' +
+                   'is not a member of (0 | 1 | 2)'));
+  });
+
+  it('returns value', function() {
+    process.env.FOO = '2';
+    eq(envvar.enum('FOO', ['0', '1', '2']), '2');
   });
 
 });


### PR DESCRIPTION
See [`envvar.enum`][1] for an explanation of the new behaviour.

I also refactored `def`, and rearranged the test suite so the various code paths are tested in order. 100% branch coverage is necessary—but not sufficient—to achieve 100% *path* coverage, and the mental effort involved in verifying that all paths are tested is reduced by this arrangement.


[1]: https://github.com/plaid/envvar/blob/dc-enum/README.md#envvarenum
