### PR TITLE
Add typescript typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ a suitable value, an `envvar.ValueError` is thrown:
 
     ValueError: Value of process.env["HTTP_MAX_SOCKETS"] does not represent a number
 
-### `envvar.enum`
+### `envvar.oneOf`
 
 This is similar to `envvar.string`, but with constraints. There may be a small
 number of valid values for a given environment variable. For example:
 
 ```javascript
-const NODE_ENV = envvar.enum('NODE_ENV', ['development', 'staging', 'production']);
+const NODE_ENV = envvar.oneOf('NODE_ENV', ['development', 'staging', 'production']);
 ```
 
 This states that `process.env.NODE_ENV` must be set to `development`,
@@ -45,7 +45,7 @@ This states that `process.env.NODE_ENV` must be set to `development`,
 A default value may be provided:
 
 ```javascript
-const NODE_ENV = envvar.enum('NODE_ENV', ['development', 'staging', 'production'], 'production');
+const NODE_ENV = envvar.oneOf('NODE_ENV', ['development', 'staging', 'production'], 'production');
 ```
 
 This states that `process.env.NODE_ENV` must either be unset (in which case the

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,40 @@
+declare module 'envvar' {
+  /**
+   * Returns the value of the specified environment variable as a string.
+   *
+   * @throws if the environment variable is not set and a default is not
+   *         specified.
+   */
+  export function string(name: string, defaultValue?: string): string;
+
+  /**
+   * Returns the value of the specified environment variable as a number.
+   *
+   * @throws if the environment variable is not set and a default is not
+   *         specified.
+   * @throws if the value of the environment variable does not represent a
+   *         number.
+   */
+  export function number(name: string, defaultValue?: number): number;
+
+  /**
+   * Returns the value of the specified environment variable as a boolean.
+   *
+   * @throws if the environment variable is not set and a default is not
+   *         specified.
+   * @throws if the value of the environment variable does not represent a
+   *         boolean.
+   */
+  export function boolean(name: string, defaultValue?: boolean): boolean;
+
+  /**
+   * Returns the value of the specified environment variable, provided that
+   * the value is one of the permissible strings.
+   *
+   * @throws if the environment variable is not set and a default is not
+   *         specified.
+   * @throws if the value of the environment variable is not one of the
+   *         permissible strings.
+   */
+  export function oneOf(name: string, allowedValues: Array<string>, defaultValue?: string): string;
+}

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ exports.string = def('String', function(name, value) {
   return value;
 });
 
-exports.enum = function(name, members, value) {
+exports.oneOf = function(name, members, value) {
   var n = arguments.length;
   if (n < 2) throw new Error('Too few arguments');
   if (n > 3) throw new Error('Too many arguments');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   },
   "files": [
     "/README.md",
+    "/index.d.ts",
     "/index.js",
     "/package.json"
-  ]
+  ],
+  "types": "./index.d.ts"
 }

--- a/test/index.js
+++ b/test/index.js
@@ -205,53 +205,53 @@ describe('envvar.string', function() {
 });
 
 
-describe('envvar.enum', function() {
+describe('envvar.oneOf', function() {
 
   it('throws if applied to too few arguments', function() {
-    throws(function() { envvar.enum(); },
+    throws(function() { envvar.oneOf(); },
            errorEq(Error, 'Too few arguments'));
-    throws(function() { envvar.enum(1); },
+    throws(function() { envvar.oneOf(1); },
            errorEq(Error, 'Too few arguments'));
   });
 
   it('throws if applied to too many arguments', function() {
-    throws(function() { envvar.enum(1, 2, 3, 4); },
+    throws(function() { envvar.oneOf(1, 2, 3, 4); },
            errorEq(Error, 'Too many arguments'));
   });
 
   it('throws a TypeError if the type contains non-string members', function() {
-    throws(function() { envvar.enum('FOO', ['0', '1', 2]); },
+    throws(function() { envvar.oneOf('FOO', ['0', '1', 2]); },
            errorEq(TypeError,
                    'Enumerated types must consist solely of string values'));
-    throws(function() { envvar.enum('FOO', ['0', '1', 2], '0'); },
+    throws(function() { envvar.oneOf('FOO', ['0', '1', 2], '0'); },
            errorEq(TypeError,
                    'Enumerated types must consist solely of string values'));
   });
 
   it('throws a TypeError if default value is not a string', function() {
-    throws(function() { envvar.enum('FOO', ['0', '1', '2'], 0); },
+    throws(function() { envvar.oneOf('FOO', ['0', '1', '2'], 0); },
            errorEq(TypeError,
                    'Default value of process.env["FOO"] ' +
                    'is not of type String'));
   });
 
   it('returns default value if variable is not set', function() {
-    eq(envvar.enum('FOO', ['0', '1', '2'], '0'), '0');
+    eq(envvar.oneOf('FOO', ['0', '1', '2'], '0'), '0');
   });
 
   it('throws an UnsetVariableError if variable is not set', function() {
-    throws(function() { envvar.enum('FOO', ['0', '1', '2']); },
+    throws(function() { envvar.oneOf('FOO', ['0', '1', '2']); },
            errorEq(envvar.UnsetVariableError,
                    'No environment variable named "FOO"'));
   });
 
   it('throws a ValueError if value is not a member of the type', function() {
     process.env.FOO = 'X';
-    throws(function() { envvar.enum('FOO', ['0', '1', '2']); },
+    throws(function() { envvar.oneOf('FOO', ['0', '1', '2']); },
            errorEq(envvar.ValueError,
                    'Value of process.env["FOO"] ' +
                    'is not a member of (0 | 1 | 2)'));
-    throws(function() { envvar.enum('FOO', ['0', '1', '2'], '0'); },
+    throws(function() { envvar.oneOf('FOO', ['0', '1', '2'], '0'); },
            errorEq(envvar.ValueError,
                    'Value of process.env["FOO"] ' +
                    'is not a member of (0 | 1 | 2)'));
@@ -259,7 +259,7 @@ describe('envvar.enum', function() {
 
   it('returns value', function() {
     process.env.FOO = '2';
-    eq(envvar.enum('FOO', ['0', '1', '2']), '2');
+    eq(envvar.oneOf('FOO', ['0', '1', '2']), '2');
   });
 
 });


### PR DESCRIPTION
regarding `enum`: I think there are two options, unless there is some way around this I do not know about.

  1. Rename the function to something else (e.g. a breaking change), perhaps `set`.. though I suppose that could also be misleading. 
  2. Leave the function undocumented / untyped (less than ideal)

What do you think @davidchambers ?